### PR TITLE
Added Resource strings for OtherAnimals Views + Facored out styles to Control Styles

### DIFF
--- a/H.Core/Properties/Resources.Designer.cs
+++ b/H.Core/Properties/Resources.Designer.cs
@@ -592,6 +592,15 @@ namespace H.Core.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add Group.
+        /// </summary>
+        public static string ButtonAddGroup {
+            get {
+                return ResourceManager.GetString("ButtonAddGroup", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Add Harvest Date.
         /// </summary>
         public static string ButtonAddHarvestDate {
@@ -601,11 +610,29 @@ namespace H.Core.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add Management Period.
+        /// </summary>
+        public static string ButtonAddManagementPeriod {
+            get {
+                return ResourceManager.GetString("ButtonAddManagementPeriod", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Add Manure Substrate Type.
         /// </summary>
         public static string ButtonAddManureSubstrateTypes {
             get {
                 return ResourceManager.GetString("ButtonAddManureSubstrateTypes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Bedding Application Calculator.
+        /// </summary>
+        public static string ButtonBeddingApplication {
+            get {
+                return ResourceManager.GetString("ButtonBeddingApplication", resourceCulture);
             }
         }
         
@@ -8035,6 +8062,15 @@ namespace H.Core.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Additional Information.
+        /// </summary>
+        public static string LabelAdditionalInformation {
+            get {
+                return ResourceManager.GetString("LabelAdditionalInformation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Add Selected Component.
         /// </summary>
         public static string LabelAddSelectComponent {
@@ -8589,6 +8625,15 @@ namespace H.Core.Properties {
         public static string LabelBeddingMaterialType {
             get {
                 return ResourceManager.GetString("LabelBeddingMaterialType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Bedding type:.
+        /// </summary>
+        public static string LabelBeddingType {
+            get {
+                return ResourceManager.GetString("LabelBeddingType", resourceCulture);
             }
         }
         
@@ -9493,6 +9538,15 @@ namespace H.Core.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to End Date.
+        /// </summary>
+        public static string LabelEndDate {
+            get {
+                return ResourceManager.GetString("LabelEndDate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Energy CO2.
         /// </summary>
         public static string LabelEnergyCO2 {
@@ -9826,6 +9880,15 @@ namespace H.Core.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to General Management.
+        /// </summary>
+        public static string LabelGeneralManagement {
+            get {
+                return ResourceManager.GetString("LabelGeneralManagement", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Gestation.
         /// </summary>
         public static string LabelGestationDiet {
@@ -9921,6 +9984,15 @@ namespace H.Core.Properties {
         public static string LabelGrossEnergy {
             get {
                 return ResourceManager.GetString("LabelGrossEnergy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Group Name.
+        /// </summary>
+        public static string LabelGroupName {
+            get {
+                return ResourceManager.GetString("LabelGroupName", resourceCulture);
             }
         }
         
@@ -10083,6 +10155,24 @@ namespace H.Core.Properties {
         public static string LabelHolosOnlySupportsCertainHardinessZones {
             get {
                 return ResourceManager.GetString("LabelHolosOnlySupportsCertainHardinessZones", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Housing Management.
+        /// </summary>
+        public static string LabelHousingManagement {
+            get {
+                return ResourceManager.GetString("LabelHousingManagement", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Housing type:.
+        /// </summary>
+        public static string LabelHousingType {
+            get {
+                return ResourceManager.GetString("LabelHousingType", resourceCulture);
             }
         }
         
@@ -10537,6 +10627,15 @@ namespace H.Core.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Management Period Name.
+        /// </summary>
+        public static string LabelManagementPeriodName {
+            get {
+                return ResourceManager.GetString("LabelManagementPeriodName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Manganese.
         /// </summary>
         public static string LabelManganese {
@@ -10551,6 +10650,24 @@ namespace H.Core.Properties {
         public static string LabelManureCarbonInput {
             get {
                 return ResourceManager.GetString("LabelManureCarbonInput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Manure handling system:.
+        /// </summary>
+        public static string LabelManureHandlingSystem {
+            get {
+                return ResourceManager.GetString("LabelManureHandlingSystem", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Manure Management.
+        /// </summary>
+        public static string LabelManureManagement {
+            get {
+                return ResourceManager.GetString("LabelManureManagement", resourceCulture);
             }
         }
         
@@ -10906,6 +11023,15 @@ namespace H.Core.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Number of animals:.
+        /// </summary>
+        public static string LabelNumberOfAnimals {
+            get {
+                return ResourceManager.GetString("LabelNumberOfAnimals", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Number of bales.
         /// </summary>
         public static string LabelNumberOfBales {
@@ -10920,6 +11046,15 @@ namespace H.Core.Properties {
         public static string LabelNumberOfBalesAvailableForSupplementalFeeding {
             get {
                 return ResourceManager.GetString("LabelNumberOfBalesAvailableForSupplementalFeeding", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Number of Days.
+        /// </summary>
+        public static string LabelNumberOfDays {
+            get {
+                return ResourceManager.GetString("LabelNumberOfDays", resourceCulture);
             }
         }
         
@@ -11743,11 +11878,74 @@ namespace H.Core.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Start Date.
+        /// </summary>
+        public static string LabelStartDate {
+            get {
+                return ResourceManager.GetString("LabelStartDate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Start year of field history.
         /// </summary>
         public static string LabelStartYearOfFieldHistory {
             get {
                 return ResourceManager.GetString("LabelStartYearOfFieldHistory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Step 1:.
+        /// </summary>
+        public static string LabelStep1 {
+            get {
+                return ResourceManager.GetString("LabelStep1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Define the animal groups for this component.
+        /// </summary>
+        public static string LabelStep1Text {
+            get {
+                return ResourceManager.GetString("LabelStep1Text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Step 2:.
+        /// </summary>
+        public static string LabelStep2 {
+            get {
+                return ResourceManager.GetString("LabelStep2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Define the management periods for the selected animal group.
+        /// </summary>
+        public static string LabelStep2Text {
+            get {
+                return ResourceManager.GetString("LabelStep2Text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Step 3:.
+        /// </summary>
+        public static string LabelStep3 {
+            get {
+                return ResourceManager.GetString("LabelStep3", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Define the management of this group of animals during the selected period of time.
+        /// </summary>
+        public static string LabelStep3Text {
+            get {
+                return ResourceManager.GetString("LabelStep3Text", resourceCulture);
             }
         }
         
@@ -15752,6 +15950,15 @@ namespace H.Core.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to General.
+        /// </summary>
+        public static string TitleGeneralTab {
+            get {
+                return ResourceManager.GetString("TitleGeneralTab", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Grazing.
         /// </summary>
         public static string TitleGrazing {
@@ -15793,6 +16000,15 @@ namespace H.Core.Properties {
         public static string TitleHarvest {
             get {
                 return ResourceManager.GetString("TitleHarvest", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Housing.
+        /// </summary>
+        public static string TitleHousingTab {
+            get {
+                return ResourceManager.GetString("TitleHousingTab", resourceCulture);
             }
         }
         
@@ -15847,6 +16063,15 @@ namespace H.Core.Properties {
         public static string TitleManureExportDetails {
             get {
                 return ResourceManager.GetString("TitleManureExportDetails", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Manure.
+        /// </summary>
+        public static string TitleManureTab {
+            get {
+                return ResourceManager.GetString("TitleManureTab", resourceCulture);
             }
         }
         

--- a/H.Core/Properties/Resources.resx
+++ b/H.Core/Properties/Resources.resx
@@ -6039,4 +6039,79 @@ Please note: emissions related to the deposition or application of livestock man
   <data name="LabelEcodistrict" xml:space="preserve">
     <value>Ecodistrict</value>
   </data>
+  <data name="ButtonAddGroup" xml:space="preserve">
+    <value>Add Group</value>
+  </data>
+  <data name="LabelStep1" xml:space="preserve">
+    <value>Step 1:</value>
+  </data>
+  <data name="LabelStep1Text" xml:space="preserve">
+    <value>Define the animal groups for this component</value>
+  </data>
+  <data name="LabelStep2" xml:space="preserve">
+    <value>Step 2:</value>
+  </data>
+  <data name="LabelStep2Text" xml:space="preserve">
+    <value>Define the management periods for the selected animal group</value>
+  </data>
+  <data name="ButtonAddManagementPeriod" xml:space="preserve">
+    <value>Add Management Period</value>
+  </data>
+  <data name="LabelStep3" xml:space="preserve">
+    <value>Step 3:</value>
+  </data>
+  <data name="LabelStep3Text" xml:space="preserve">
+    <value>Define the management of this group of animals during the selected period of time</value>
+  </data>
+  <data name="LabelGroupName" xml:space="preserve">
+    <value>Group Name</value>
+  </data>
+  <data name="LabelStartDate" xml:space="preserve">
+    <value>Start Date</value>
+  </data>
+  <data name="LabelEndDate" xml:space="preserve">
+    <value>End Date</value>
+  </data>
+  <data name="LabelNumberOfDays" xml:space="preserve">
+    <value>Number of Days</value>
+  </data>
+  <data name="LabelManagementPeriodName" xml:space="preserve">
+    <value>Management Period Name</value>
+  </data>
+  <data name="TitleGeneralTab" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="TitleHousingTab" xml:space="preserve">
+    <value>Housing</value>
+  </data>
+  <data name="TitleManureTab" xml:space="preserve">
+    <value>Manure</value>
+  </data>
+  <data name="LabelGeneralManagement" xml:space="preserve">
+    <value>General Management</value>
+  </data>
+  <data name="LabelHousingManagement" xml:space="preserve">
+    <value>Housing Management</value>
+  </data>
+  <data name="LabelManureManagement" xml:space="preserve">
+    <value>Manure Management</value>
+  </data>
+  <data name="LabelAdditionalInformation" xml:space="preserve">
+    <value>Additional Information</value>
+  </data>
+  <data name="LabelNumberOfAnimals" xml:space="preserve">
+    <value>Number of animals:</value>
+  </data>
+  <data name="LabelHousingType" xml:space="preserve">
+    <value>Housing type:</value>
+  </data>
+  <data name="LabelBeddingType" xml:space="preserve">
+    <value>Bedding type:</value>
+  </data>
+  <data name="ButtonBeddingApplication" xml:space="preserve">
+    <value>Bedding Application Calculator</value>
+  </data>
+  <data name="LabelManureHandlingSystem" xml:space="preserve">
+    <value>Manure handling system:</value>
+  </data>
 </root>

--- a/H.GUI.Avalonia/H.Avalonia/Styles/ControlsStyles.axaml
+++ b/H.GUI.Avalonia/H.Avalonia/Styles/ControlsStyles.axaml
@@ -48,7 +48,23 @@
         <Setter Property="FontFamily" Value="{DynamicResource RobotoFontFamily}" />
         <Setter Property="Background" Value="MediumAquamarine"/>
     </Style>
-    
+	<Style Selector="Button.add-management-period">
+		<Setter Property="Margin" Value="10,20,0,0"/>
+		<Setter Property="BorderBrush" Value="#D7D7D7"/>   
+		<Setter Property="Background" Value="White"/>
+		<Setter Property="Foreground" Value="#605D5D"/>
+		<Setter Property="Width" Value="275"/>
+		<Setter Property="Height" Value="45"/>
+	</Style>
+	<Style Selector="Button.add-group">
+		<Setter Property="Margin" Value="10,20,0,0"/>
+		<Setter Property="BorderBrush" Value="#D7D7D7"/>
+		<Setter Property="Background" Value="White"/>
+		<Setter Property="Foreground" Value="#605D5D"/>
+		<Setter Property="Width" Value="175"/>
+		<Setter Property="Height" Value="40"/>
+	</Style>
+	
     <!-- DataGrid Styles -->
     <Style Selector="DataGridCell NumericUpDown">
         <Setter Property="BorderThickness" Value="0"/>
@@ -83,6 +99,22 @@
         <Setter Property="TextWrapping" Value="Wrap" />
         <Setter Property="VerticalAlignment" Value="Center" />
 	</Style>
-    
 
+	<!-- DataValidationErrors Styles-->
+	    <!--Textblock-->
+		<Style Selector="DataValidationErrors">
+			<Setter Property="ErrorTemplate">
+				<DataTemplate>
+					<ItemsControl ItemsSource="{Binding}">
+						<ItemsControl.Styles>
+							<Style Selector="TextBlock">
+								<Setter Property="FontSize" Value="12"/>
+								<Setter Property="TextWrapping" Value="Wrap" />
+								<Setter Property="Foreground" Value="Red"/>
+							</Style>
+						</ItemsControl.Styles>
+					</ItemsControl>
+				</DataTemplate>
+			</Setter>
+		</Style>
 </Styles>

--- a/H.GUI.Avalonia/H.Avalonia/Styles/ControlsStyles.axaml
+++ b/H.GUI.Avalonia/H.Avalonia/Styles/ControlsStyles.axaml
@@ -100,6 +100,22 @@
         <Setter Property="VerticalAlignment" Value="Center" />
 	</Style>
 
+	<!-- TextBox Styles -->
+	<Style Selector="TextBox.view-title">
+		<Setter Property="FontSize" Value="36"/>
+		<Setter Property="FontWeight" Value="Bold"/>
+		<Setter Property="Margin" Value="10,10,0,0"/>
+		<Setter Property="Foreground" Value="#605D5D"/>
+		<Setter Property="BorderThickness" Value="0"/>
+	</Style>
+	
+	<!-- Border Styles -->
+	<Style Selector="Border.title-underline">
+		<Setter Property="BorderBrush" Value="#D7D7D7"/>
+		<Setter Property="BorderThickness" Value="0,0,0,3"/>
+		<Setter Property="Margin" Value="0,10,0,0"/>
+	</Style>
+
 	<!-- DataValidationErrors Styles-->
 	    <!--Textblock-->
 		<Style Selector="DataValidationErrors">

--- a/H.GUI.Avalonia/H.Avalonia/ViewModels/ComponentViews/OtherAnimals/OtherAnimalsViewModelBase.cs
+++ b/H.GUI.Avalonia/H.Avalonia/ViewModels/ComponentViews/OtherAnimals/OtherAnimalsViewModelBase.cs
@@ -46,7 +46,7 @@ namespace H.Avalonia.ViewModels.ComponentViews.OtherAnimals
         }
 
         /// <summary>
-        ///  The type of animal a respective component represents, used in the Groups collection / Groups data grid in the view(s), value set in child classes.
+        ///  The <see cref="AnimalType"/> a respective component represents, used in the <see cref="Groups"/> collection / Groups data grid in the view(s), value set in child classes.
         /// </summary>
         public AnimalType OtherAnimalType
         {
@@ -55,7 +55,7 @@ namespace H.Avalonia.ViewModels.ComponentViews.OtherAnimals
         }
 
         /// <summary>
-        /// An Observable Collection that holds ManagementPeriod objects, binded to a DataGrid in the view(s).
+        /// An Observable Collection that holds <see cref="ManagementPeriod"/> objects, binded to a DataGrid in the view(s).
         /// </summary>
         public ObservableCollection<ManagementPeriod> ManagementPeriods
         {
@@ -64,7 +64,7 @@ namespace H.Avalonia.ViewModels.ComponentViews.OtherAnimals
         }
 
         /// <summary>
-        /// An Observable Collection that holds AnimalGroup objects, binded to a DataGrid in the view(s).
+        /// An Observable Collection that holds <see cref="AnimalGroup"/> objects, binded to a DataGrid in the view(s).
         /// </summary>
         public ObservableCollection<AnimalGroup> Groups
         {
@@ -82,7 +82,7 @@ namespace H.Avalonia.ViewModels.ComponentViews.OtherAnimals
         }
 
         /// <summary>
-        ///  Binded to a button in the view, adds an item to the Groups collection / a row to the respective binded DataGrid. Seeded with OtherAnimalType.
+        ///  Binded to a button in the view, adds an item to the <see cref="Groups"/> collection / a row to the respective binded DataGrid. Seeded with <see cref="OtherAnimalType"/>.
         /// </summary>
         public void HandleAddGroupEvent()
         {
@@ -90,7 +90,7 @@ namespace H.Avalonia.ViewModels.ComponentViews.OtherAnimals
         }
 
         /// <summary>
-        ///  Binded to a button in the view, adds an item to the ManagementPeriods collection / a row to the respective binded DataGrid. Seeded with some default values.
+        ///  Binded to a button in the view, adds an item to the <see cref="ManagementPeriods"/> collection / a row to the respective binded DataGrid. Seeded with some default values.
         /// </summary>
         public void HandleAddManagementPeriodEvent()
         {
@@ -104,7 +104,7 @@ namespace H.Avalonia.ViewModels.ComponentViews.OtherAnimals
         #region Private Methods
 
         /// <summary>
-        /// Ensures that a user cannot leave the ViewName empty when editing it in the UI. Uses INotifyDataErrorInfo implementation in ViewModelBase.
+        /// Ensures that a user cannot leave the <see cref="ViewName"/> empty when editing it in the UI. Uses INotifyDataErrorInfo implementation in <see cref="ViewModelBase"/>.
         /// </summary>
         private void ValidateViewName()
         {

--- a/H.GUI.Avalonia/H.Avalonia/Views/ComponentViews/OtherAnimals/OtherAnimalsComponentsView.axaml
+++ b/H.GUI.Avalonia/H.Avalonia/Views/ComponentViews/OtherAnimals/OtherAnimalsComponentsView.axaml
@@ -6,25 +6,6 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="H.Avalonia.OtherAnimalsComponentsView">
 
-	<!-- Overriding the default styling of error messages -->
-	<UserControl.Styles>
-		<Style Selector="DataValidationErrors">
-			<Setter Property="ErrorTemplate">
-				<DataTemplate>
-					<ItemsControl ItemsSource="{Binding}">
-						<ItemsControl.Styles>
-							<Style Selector="TextBlock">
-								<Setter Property="FontSize" Value="12"/>
-								<Setter Property="TextWrapping" Value="Wrap" />
-								<Setter Property="Foreground" Value="Red"/>
-							</Style>
-						</ItemsControl.Styles>
-					</ItemsControl>
-				</DataTemplate>
-			</Setter>
-		</Style>
-	</UserControl.Styles>
-
 	<Grid>
 		<Grid.RowDefinitions>
 			<!-- Title -->

--- a/H.GUI.Avalonia/H.Avalonia/Views/ComponentViews/OtherAnimals/OtherAnimalsComponentsView.axaml
+++ b/H.GUI.Avalonia/H.Avalonia/Views/ComponentViews/OtherAnimals/OtherAnimalsComponentsView.axaml
@@ -16,8 +16,8 @@
 
 		<StackPanel Grid.Row="0">
 			<!-- Title -->
-			<TextBox Text="{Binding Path=ViewName}" FontSize="36" FontWeight="Bold" Margin="10,10,0,0" Foreground="#605D5D" BorderThickness="0"/>
-			<Border BorderBrush="#D7D7D7" BorderThickness="0,0,0,3" Margin="0,10,0,0"/>
+			<TextBox Classes="view-title" Text="{Binding Path=ViewName}"/> 
+			<Border Classes="title-underline"/> 
 		</StackPanel>
 
 		<ScrollViewer Grid.Row="1">

--- a/H.GUI.Avalonia/H.Avalonia/Views/ComponentViews/OtherAnimals/OtherAnimalsStep1View.axaml
+++ b/H.GUI.Avalonia/H.Avalonia/Views/ComponentViews/OtherAnimals/OtherAnimalsStep1View.axaml
@@ -2,22 +2,21 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:properties="clr-namespace:H.Core.Properties;assembly=H.Core"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="H.Avalonia.OtherAnimalsStep1View">
 	
 	<StackPanel>
 		<TextBlock FontSize="16" Margin="10,20,0,0" Foreground="#605D5D">
-			<Run Text="Step 1:" FontWeight="Bold"/>
-			<Run Text="Define the animal groups for this"/> 
-			<Run Text="{Binding ViewName}"/>
-			<Run Text="component"/>
+			<Run Text="{x:Static properties:Resources.LabelStep1}" FontWeight="Bold"/>
+			<Run Text="{x:Static properties:Resources.LabelStep1Text}"/> 
 		</TextBlock>
 
-		<Button Command="{Binding HandleAddGroupEvent}" Classes="add-group">Add Group</Button>
+		<Button Command="{Binding HandleAddGroupEvent}" Classes="add-group" Content="{x:Static properties:Resources.ButtonAddGroup}"></Button>
 		<StackPanel>
 			<DataGrid ItemsSource="{Binding Path=Groups}" AutoGenerateColumns="False" Margin="10,20,0,0" HorizontalAlignment="Left" BorderThickness="1" GridLinesVisibility="All" Height="75">
 				<DataGrid.Columns>
-					<DataGridTextColumn Width="Auto" Header="Group Name" Binding="{Binding Path=GroupType}"/>
+					<DataGridTextColumn Width="Auto" Header="{x:Static properties:Resources.LabelGroupName}" Binding="{Binding Path=GroupType}"/>
 				</DataGrid.Columns>
 			</DataGrid>
 		</StackPanel>

--- a/H.GUI.Avalonia/H.Avalonia/Views/ComponentViews/OtherAnimals/OtherAnimalsStep1View.axaml
+++ b/H.GUI.Avalonia/H.Avalonia/Views/ComponentViews/OtherAnimals/OtherAnimalsStep1View.axaml
@@ -13,7 +13,7 @@
 			<Run Text="component"/>
 		</TextBlock>
 
-		<Button Command="{Binding HandleAddGroupEvent}" Margin="10,20,0,0" BorderBrush="#D7D7D7" Background="White" Foreground="#605D5D" Height="40" Width="175">Add Group</Button>
+		<Button Command="{Binding HandleAddGroupEvent}" Classes="add-group">Add Group</Button>
 		<StackPanel>
 			<DataGrid ItemsSource="{Binding Path=Groups}" AutoGenerateColumns="False" Margin="10,20,0,0" HorizontalAlignment="Left" BorderThickness="1" GridLinesVisibility="All" Height="75">
 				<DataGrid.Columns>

--- a/H.GUI.Avalonia/H.Avalonia/Views/ComponentViews/OtherAnimals/OtherAnimalsStep2View.axaml
+++ b/H.GUI.Avalonia/H.Avalonia/Views/ComponentViews/OtherAnimals/OtherAnimalsStep2View.axaml
@@ -2,23 +2,24 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:properties="clr-namespace:H.Core.Properties;assembly=H.Core"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="H.Avalonia.OtherAnimalsStep2View">
 
 	<StackPanel>
 			<TextBlock FontSize="16" Margin="10,20,0,0" Foreground="#605D5D">
-				<Run Text="Step 2:" FontWeight="Bold"/>
-				<Run Text="Define the management periods for the selected animal group"/>
+				<Run Text="{x:Static properties:Resources.LabelStep2}" FontWeight="Bold"/>
+				<Run Text="{x:Static properties:Resources.LabelStep2Text}"/>
 			</TextBlock>
 
-			<Button Command="{Binding HandleAddManagementPeriodEvent}" Classes="add-management-period">Add Management Period</Button> 
+			<Button Command="{Binding HandleAddManagementPeriodEvent}" Classes="add-management-period" Content="{x:Static properties:Resources.ButtonAddManagementPeriod}"></Button> 
 			<StackPanel>
 				<DataGrid ItemsSource="{Binding Path=ManagementPeriods}" AutoGenerateColumns="False" Margin="10,20,0,0" HorizontalAlignment="Left" BorderThickness="1" GridLinesVisibility="All" Height="100">
 					<DataGrid.Columns>
-						<DataGridTextColumn Width="Auto" Header="Management Period Name" Binding="{Binding Path=GroupName}"/>
-						<DataGridTextColumn Width="Auto" Header="Start Date" Binding="{Binding Path=Start}"/>
-						<DataGridTextColumn Width="Auto" Header="End Date" Binding="{Binding Path=End}"/>
-						<DataGridTextColumn Width="Auto" Header="Number of Days" Binding="{Binding Path=NumberOfDays}"/>
+						<DataGridTextColumn Width="Auto" Header="{x:Static properties:Resources.LabelManagementPeriodName}" Binding="{Binding Path=GroupName}"/>
+						<DataGridTextColumn Width="Auto" Header="{x:Static properties:Resources.LabelStartDate}" Binding="{Binding Path=Start}"/>
+						<DataGridTextColumn Width="Auto" Header="{x:Static properties:Resources.LabelEndDate}" Binding="{Binding Path=End}"/>
+						<DataGridTextColumn Width="Auto" Header="{x:Static properties:Resources.LabelNumberOfDays}" Binding="{Binding Path=NumberOfDays}"/>
 					</DataGrid.Columns>
 				</DataGrid>
 			</StackPanel>

--- a/H.GUI.Avalonia/H.Avalonia/Views/ComponentViews/OtherAnimals/OtherAnimalsStep2View.axaml
+++ b/H.GUI.Avalonia/H.Avalonia/Views/ComponentViews/OtherAnimals/OtherAnimalsStep2View.axaml
@@ -11,7 +11,7 @@
 				<Run Text="Define the management periods for the selected animal group"/>
 			</TextBlock>
 
-			<Button Command="{Binding HandleAddManagementPeriodEvent}" Margin="10,20,0,0" BorderBrush="#D7D7D7" Background="White" Foreground="#605D5D" Width="275" Height="45">Add Management Period </Button>
+			<Button Command="{Binding HandleAddManagementPeriodEvent}" Classes="add-management-period">Add Management Period</Button> 
 			<StackPanel>
 				<DataGrid ItemsSource="{Binding Path=ManagementPeriods}" AutoGenerateColumns="False" Margin="10,20,0,0" HorizontalAlignment="Left" BorderThickness="1" GridLinesVisibility="All" Height="100">
 					<DataGrid.Columns>

--- a/H.GUI.Avalonia/H.Avalonia/Views/ComponentViews/OtherAnimals/OtherAnimalsStep3View.axaml
+++ b/H.GUI.Avalonia/H.Avalonia/Views/ComponentViews/OtherAnimals/OtherAnimalsStep3View.axaml
@@ -2,71 +2,64 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:properties="clr-namespace:H.Core.Properties;assembly=H.Core"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="H.Avalonia.OtherAnimalsStep3View">
 
 	<StackPanel>
 		<TextBlock FontSize="16" Margin="10,20,0,0" Foreground="#605D5D">
-			<Run Text="Step 3:" FontWeight="Bold"/>
-			<Run Text=" Define the management of"/>
-			<Run Text="{Binding ViewName}"/>
-			<Run Text="during this selected period of time"/>
+			<Run Text="{x:Static properties:Resources.LabelStep3}" FontWeight="Bold"/>
+			<Run Text="{x:Static properties:Resources.LabelStep3Text}"/>
 		</TextBlock>
 		<TabControl>
 			<!--General tab-->
-			<TabItem Header="General" FontSize="18">
+			<TabItem Header="{x:Static properties:Resources.TitleGeneralTab}" FontSize="18">
 				<StackPanel Margin="10, 20, 10, 10">
-					<TextBlock FontSize="16" Foreground="#605D5D" FontWeight="Bold">General Management</TextBlock>
-					<TextBlock FontSize="16" Foreground="#605D5D" TextWrapping="Wrap">
-						Basic information about this group of animals can be entered here. Values entered here will apply to the animals during the selected management period.
-					</TextBlock>
+					<TextBlock FontSize="16" Foreground="#605D5D" FontWeight="Bold" Text="{x:Static properties:Resources.LabelGeneralManagement}"/>
+					<TextBlock FontSize="16" Foreground="#605D5D" TextWrapping="Wrap" Text="{x:Static properties:Resources.MessageAnimalGeneralTab}"/>
 					<StackPanel Orientation="Horizontal">
-						<TextBlock FontSize="16" Margin="0,20,10,20" Foreground="#605D5D" TextWrapping="Wrap">Number of animals: </TextBlock>
+						<TextBlock FontSize="16" Margin="0,20,10,20" Foreground="#605D5D" TextWrapping="Wrap" Text="{x:Static properties:Resources.LabelNumberOfAnimals}"/>
 						<NumericUpDown Value="10" HorizontalAlignment="Right" VerticalAlignment="Center" Increment="1" Padding="10"/>
 					</StackPanel>
 				</StackPanel>
 			</TabItem>
 			<!--Housing tab-->
-			<TabItem Header="Housing" FontSize="18">
+			<TabItem Header="{x:Static properties:Resources.TitleHousingTab}" FontSize="18">
 				<StackPanel Margin="10,20,10,10" Orientation="Horizontal">
 					<Grid ColumnDefinitions="400,300*" HorizontalAlignment="Stretch">
 						<!-- Left side -->
 						<StackPanel Grid.Column="0" HorizontalAlignment="Left" Margin="10" Spacing="5">
-							<TextBlock FontSize="16" Foreground="#605D5D" FontWeight="Bold"> Housing Management </TextBlock>
-							<TextBlock FontSize="16" Foreground="#605D5D" TextWrapping="WrapWithOverflow">
-								Animal housing details can be entered on this tab.
-							</TextBlock>
+							<TextBlock FontSize="16" Foreground="#605D5D" FontWeight="Bold" Text="{x:Static properties:Resources.LabelHousingManagement}"/>
+							<TextBlock FontSize="16" Foreground="#605D5D" TextWrapping="WrapWithOverflow" Text="{x:Static properties:Resources.MessageAnimalHousingTab}"/>
 							<StackPanel Orientation="Horizontal" Margin="0,20,0,0">
-								<TextBlock FontSize="16" VerticalAlignment="Center" Margin="0,0,10,0" Foreground="#605D5D" TextWrapping="Wrap">Housing type: </TextBlock>
+								<TextBlock FontSize="16" VerticalAlignment="Center" Margin="0,0,10,0" Foreground="#605D5D" TextWrapping="Wrap" Text="{x:Static properties:Resources.LabelHousingType}"/>
 								<ComboBox SelectedIndex="0" MaxDropDownHeight="100">
-									<ComboBoxItem>Housed in barn</ComboBoxItem>
-									<ComboBoxItem>Confined no barn</ComboBoxItem>
-									<ComboBoxItem>Pasture/range/paddock</ComboBoxItem>
+									<ComboBoxItem Content="{x:Static properties:Resources.HousedInBarn}"/>
+									<ComboBoxItem Content="{x:Static properties:Resources.ConfinedNoBarn}"/>
+									<ComboBoxItem Content="{x:Static properties:Resources.PastureHandlingSystemName}"/>
 								</ComboBox>
 							</StackPanel>
 						</StackPanel>
 						<!--Right side-->
 						<StackPanel Grid.Column="1" HorizontalAlignment="Right" Margin="10" Spacing="5">
-							<TextBlock FontSize="16" Foreground="#605D5D" FontWeight="Bold"> Additional Information </TextBlock>
-							<TextBlock Text="Bedding type:"/>
-							<Button>Bedding Application Calculator</Button>
+							<TextBlock FontSize="16" Foreground="#605D5D" FontWeight="Bold" Text="{x:Static properties:Resources.LabelAdditionalInformation}"/>
+							<TextBlock Text="{x:Static properties:Resources.LabelBeddingType}"/>
+							<Button Content="{x:Static properties:Resources.ButtonBeddingApplication}"/>
 						</StackPanel>
 					</Grid>
 				</StackPanel>
 			</TabItem>
 			<!--Manure Tab-->
-			<TabItem Header="Manure" FontSize="18">
+			<TabItem Header="{x:Static properties:Resources.TitleManureTab}" FontSize="18">
 				<StackPanel Margin="10, 20, 10, 10" HorizontalAlignment="Left">
-					<TextBlock FontSize="16" Foreground="#605D5D" FontWeight="Bold">Manure</TextBlock>
-					<TextBlock FontSize="16" Foreground="#605D5D" TextWrapping="Wrap">
-						Manure handling system details can be entered on this tab.
-					</TextBlock>
+					<TextBlock FontSize="16" Foreground="#605D5D" FontWeight="Bold" Text="{x:Static properties:Resources.LabelManureManagement}"/>
+					<TextBlock FontSize="16" Foreground="#605D5D" TextWrapping="Wrap" Text="{x:Static properties:Resources.MessageAnimalManureTab}"/>
 					<StackPanel Orientation="Horizontal" >
-						<TextBlock FontSize="16" Margin="0,25,10,20" Foreground="#605D5D" TextWrapping="Wrap">Manure handling system:</TextBlock>
+						<TextBlock FontSize="16" Margin="0,25,10,20" Foreground="#605D5D" TextWrapping="Wrap" Text="{x:Static properties:Resources.LabelManureHandlingSystem}"/>
 						<StackPanel Orientation="Horizontal" Margin="0,20,0,0">
 							<ComboBox SelectedIndex="0" MaxDropDownHeight="100">
-								<ComboBoxItem>Solid storage (stockpiled)</ComboBoxItem>
-								<ComboBoxItem>Pasture/range/paddock</ComboBoxItem>
+								<ComboBoxItem Content="{x:Static properties:Resources.SolidStorageHandlingSystemName}"/>
+								<ComboBoxItem Content="{x:Static properties:Resources.PastureHandlingSystemName}"/>
 							</ComboBox>
 						</StackPanel>
 					</StackPanel>


### PR DESCRIPTION
Created resource strings for the text content found in all of the OtherAnimals view files. Factored out styling for DataValidationErrors, buttons, and the view titles to ControlStyles. Also added the `<see>` tag to comments in the OtherAnimalsViewModelBase file. Essentially this PR addresses the comments from the recent PR that was merged (#30).